### PR TITLE
Fix the Travis-CI badge to refer to the right repo

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-[![Build Status](https://travis-ci.org/gabetax/isolated_server.svg?branch=master)](https://travis-ci.org/gabetax/isolated_server)
+[![Build Status](https://travis-ci.org/zendesk/isolated_server.svg?branch=master)](https://travis-ci.org/zendesk/isolated_server)
 
 # Mysql Isolated Servers -- a gem for testing mysql stuff
 


### PR DESCRIPTION
@zendesk/hadoken 