### PR TITLE
Fix Travis-CI build

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,11 @@
+sudo: required
+
 language: ruby
+
 rvm:
   - 2.1.8
   - 2.2.4
   - 2.3.0
+
+before_script:
+  - sudo cp /usr/share/doc/mysql-server-5.6/examples/my-default.cnf /usr/share/mysql/my-default.cnf


### PR DESCRIPTION
The Travis-CI build for this gem has been broken for some time due to changes in the Travis-CI build infrastructure.

Specifically, the `my-default.cnf` file which `mysql_install_db` uses as a template for `my.cnf` is not in the location that `mysql_install_db` expects. We can copy it to the right location using a `before_script`, but that requires `sudo`, so we needed `sudo: required` on the whole Travis build.

Further, this was really hard to debug since the gem swallows most command output. This improves that by having any failed `system` call capture all its stdout and stderr and output it in the exception message.